### PR TITLE
Add cosmic-applet-package-updater to applets.ron

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -109,6 +109,12 @@ Applets(
       description: "A Music Player control applet for COSMIC panel",
       repo: "https://github.com/Ebbo/cosmic-applet-music-player",
       image: "https://raw.githubusercontent.com/Ebbo/cosmic-applet-music-player/master/Music_Player_Applet_Controls.png"
+    ),
+    (
+      name: "cosmic-applet-package-updater",
+      description: "Package update notifier applet for the COSMIC desktop",
+      repo: "https://github.com/Ebbo/cosmic-applet-package-updater",
+      image: "https://raw.githubusercontent.com/Ebbo/cosmic-applet-package-updater/master/screenshots/Package-Updater-Main.png"
     )
   ]
 )


### PR DESCRIPTION
Hi again, I would love to add my second applet cosmic-applet-package-updater - which might be the last one - but I think this one could be useful for other users as well since it works on the most common distributions + flatpak support :)