### PR TITLE
Add cosmic-speech-to-text applet

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -198,6 +198,11 @@ Applets(
       description: "Battery power monitor applet for the COSMIC™ desktop",
       repo: "https://github.com/AceMythos/cosmic-power-monitor",
       image: "https://raw.githubusercontent.com/AceMythos/cosmic-power-monitor/main/screenshots/popup.png"
+    ),
+    (
+      name: "cosmic-speech-to-text",
+      description: "Speech-to-text panel applet — record voice and type transcribed text into any app. Supports Mistral, OpenAI, and local whisper.cpp",
+      repo: "https://github.com/raph-ael/cosmic-speech-to-text",
     )
   ]
 )


### PR DESCRIPTION
## Summary
- Adds **cosmic-speech-to-text** — a speech-to-text panel applet for COSMIC
- Record voice and have it transcribed and typed into any application
- Supports three backends: Mistral API, OpenAI Whisper API, and local whisper.cpp (fully offline)
- Features: global hotkey, one-click model download, multi-language UI (EN/DE/ES/FR)

Repo: https://github.com/raph-ael/cosmic-speech-to-text