### PR TITLE
Add cosmic-speech-to-text and cosmic-keepass applets

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -209,6 +209,11 @@ Applets(
       description: "Shows active media in the panel",
       repo: "https://github.com/cosmic-utils/cosmic-ext-applet-now-playing",
       image: "https://github.com/cosmic-utils/cosmic-ext-applet-now-playing/blob/main/res/screenshot-2.png"
+    ),
+    (
+      name: "cosmic-keepass",
+      description: "KeePass password manager panel applet — search, copy, and manage passwords from .kdbx databases",
+      repo: "https://github.com/raph-ael/cosmic-keepass",
     )
   ]
 )


### PR DESCRIPTION
## Summary
- **cosmic-speech-to-text** — Speech-to-text panel applet. Record voice, transcribe via Mistral/OpenAI/local whisper.cpp, type into any app.
- **cosmic-keepass** — KeePass password manager panel applet. Search, copy, and manage passwords from .kdbx databases.

Repos:
- https://github.com/raph-ael/cosmic-speech-to-text
- https://github.com/raph-ael/cosmic-keepass