### PR TITLE
Add cosmic-cpufreq applet

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -168,6 +168,12 @@ Applets(
       description: "Weather applet with NWS and Open-Meteo forecasts",
       repo: "https://github.com/nwxnw/cosmic-ext-whether",
       image: "https://raw.githubusercontent.com/nwxnw/cosmic-ext-whether/master/screenshots/whether.png"
+    ),
+    (
+      name: "cosmic-cpufreq",
+      description: "CPU frequency monitor and governor control applet",
+      repo: "https://github.com/skylord123/cosmic-cpufreq",
+      image: "https://github.com/skylord123/cosmic-cpufreq/raw/master/img.png"
     )
   ]
 )

--- a/applets.ron
+++ b/applets.ron
@@ -233,5 +233,11 @@ Applets(
       repo: "https://github.com/nick42d/cosmic-applet-arch",
       image: "https://github.com/user-attachments/assets/69c49436-226f-4349-afae-94d34694d565"
     ),
+    (
+      name: "cosmic-cpufreq",
+      description: "CPU frequency monitor and governor control applet",
+      repo: "https://github.com/skylord123/cosmic-cpufreq",
+      image: "https://github.com/skylord123/cosmic-cpufreq/raw/master/img.png"
+    )
   ]
 )


### PR DESCRIPTION
## Summary

Add `cosmic-cpufreq` to the COSMIC applet collection.

This applet provides CPU frequency and power-management controls from the COSMIC panel, including turbo, governor, energy preference, scaling limits, and live frequency/usage display.

![cosmic-cpufreq](https://github.com/skylord123/cosmic-cpufreq/raw/master/img.png)

## Highlights

- panel CPU frequency display
- popup controls for turbo, governor, EPP, and min/max scaling frequency
- per-core frequency view
- CPU and memory usage bars
- configurable popup layout and display preferences