### PR TITLE
Add CandyFactory · Cotton Candy Parlor themes for COSMIC

### DIFF
--- a/themes.ron
+++ b/themes.ron
@@ -13,6 +13,11 @@ Themes(
       description: "Website for https://cosmic-themes.org",
       repo: "https://github.com/Fingel/cosmic-themes-org-py",
       image: "https://raw.githubusercontent.com/Fingel/cosmic-themes-org-py/refs/heads/main/static/img/logo.webp"
+    ),
+    (
+      name: "candyfactory-cosmic",
+      description: "Dark + light COSMIC themes with matching cosmic-term scheme",
+      repo: "https://github.com/BonfireAI/candyfactory-cosmic"
     )
   ]
 )


### PR DESCRIPTION
## Summary

Adds `BonfireAI/candyfactory-cosmic` as a third entry in `themes.ron` — a dark + light COSMIC theme set with a matching `cosmic-term` color scheme. First community theme submission to the `Themes` section since June 2024.

## What changed

Single addition to `themes.ron`, appended as the third item in the `list:` — adds a trailing comma after the existing `cosmic-themes` entry's closing `)` and inserts:

```ron
(
  name: "candyfactory-cosmic",
  description: "Dark + light COSMIC themes with matching cosmic-term scheme",
  repo: "https://github.com/BonfireAI/candyfactory-cosmic"
)
```

## Image field — follow-up

The `image:` field is intentionally omitted in this PR. Per the `#![enable(implicit_some)]` directive at the top of `themes.ron`, the field is `Option<String>` and the entry parses cleanly without it. Screenshots for the project are scheduled to land on `BonfireAI/candyfactory-cosmic`'s `main` branch in the next few days; I'll open a small follow-up PR adding `image: "https://raw.githubusercontent.com/BonfireAI/candyfactory-cosmic/main/assets/screenshots/bonfire-desktop.png"` once that asset is hosted. Happy to delay this PR until then if preferred — let me know.

## Why include

The two existing `themes.ron` entries cover broad-aesthetic territory (catppuccin pastel; cosmic-themes.org as a meta-link). `candyfactory-cosmic` fills a different visual niche — pink + grape + cream over ink — that the current top-of-cosmic-themes.org does not occupy. Adds a third distinct visual direction to the section.

## License

MIT (the listing repo). Consistent with the existing catppuccin/MIT entry.

## Notes

- I confirmed this is a `themes.ron` addition (the README's "How to add your project?" copy names only `applications.ron` and `applets.ron`; the `Themes` section accepts entries, just isn't documented in that paragraph).
- I did NOT edit `README.md` — it's auto-generated from the `.ron` source files by `src/readme.rs` on push to `main`. (Noted from PR #60's rejection precedent.)
- I attempted local validation with `cargo run` but Rust is not installed on this machine — the diff is manually verified for paren balance (5/5) and the structure matches the two existing entries verbatim. If the post-merge `cargo run` panics, please ping me and I'll fix the malformed RON.

Thank you for maintaining this.