### PR TITLE
Add cosmic-applet-claude-usage applet

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -238,6 +238,12 @@ Applets(
       description: "CPU frequency monitor and governor control applet",
       repo: "https://github.com/skylord123/cosmic-cpufreq",
       image: "https://github.com/skylord123/cosmic-cpufreq/raw/master/img.png"
+    ),
+    (
+      name: "cosmic-applet-claude-usage",
+      description: "Minimal panel applet showing Claude Code usage as a quiet, color-coded indicator",
+      repo: "https://github.com/osterbergsimon/cosmic-applet-claude-usage",
+      image: "https://raw.githubusercontent.com/osterbergsimon/cosmic-applet-claude-usage/master/res/screenshots/popup.png"
     )
   ]
 )


### PR DESCRIPTION
Adds [cosmic-applet-claude-usage](https://github.com/osterbergsimon/cosmic-applet-claude-usage) to the applets list.

A minimal COSMIC panel applet showing Claude Code usage as a quiet, color-coded indicator (green → amber → red toward the session/weekly limit). Several indicator styles (dot, fill bar, ring, vertical bar) and time-to-reset displays, a click popup with reset countdowns, and a settings panel with a live preview.

GPL-3.0, with a tagged release (v0.1.1) shipping a `.deb` (Pop!_OS/Ubuntu/Debian), a portable tarball, and a Nix flake with a Cachix binary cache for prebuilt installs.