### PR TITLE
Add Cloud Mounter applet

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -168,6 +168,12 @@ Applets(
       description: "Weather applet with NWS and Open-Meteo forecasts",
       repo: "https://github.com/nwxnw/cosmic-ext-whether",
       image: "https://raw.githubusercontent.com/nwxnw/cosmic-ext-whether/master/screenshots/whether.png"
+    ),
+    (
+      name: "cosmic-ext-applet-mounter",
+      description: "Manage online mounts and offline mirrors for OneDrive, Google Drive, Box, and SMB",
+      repo: "https://github.com/uutzinger/cosmic-ext-applet-mounter",
+      image: "https://raw.githubusercontent.com/uutzinger/cosmic-ext-applet-mounter/master/resources/Popup.png"
     )
   ]
 )


### PR DESCRIPTION
## Summary

Add COSMIC Cloud Mounter to the community applet collection.

The applet manages online mounts and offline mirrors for OneDrive, Google Drive, Box, and SMB.

Source: https://github.com/uutzinger/cosmic-ext-applet-mounter

## Validation

- Parsed the updated applets.ron with the repository generator
- Verified the generated README and website entries
- Verified the public screenshot URL returns HTTP 200