### PR TITLE
feat: add cosmic-ext-app-switcher applet

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -174,6 +174,12 @@ Applets(
       description: "Manage online mounts and offline mirrors for OneDrive, Google Drive, Box, and SMB",
       repo: "https://github.com/uutzinger/cosmic-ext-applet-mounter",
       image: "https://raw.githubusercontent.com/uutzinger/cosmic-ext-applet-mounter/master/resources/Popup.png"
+    ),
+    (
+      name: "cosmic-ext-app-switcher",
+      description: "macOS-style Super+Tab app switcher for COSMIC — horizontal icon strip overlay with Dark, Light, Frosted, and Midnight themes",
+      repo: "https://github.com/j0rdiun/cosmic-ext-app-switcher",
+      image: "https://raw.githubusercontent.com/j0rdiun/cosmic-ext-app-switcher/main/docs/screenshot-applet.png"
     )
   ]
 )


### PR DESCRIPTION
Adds `cosmic-ext-app-switcher` to the applets list.

A macOS-style Super+Tab app switcher for COSMIC — replaces the default vertical window list with a horizontal icon strip overlay. Includes a panel applet for theme switching (Dark, Light, Frosted, Midnight) and a one-click Super+Tab shortcut toggle.

- **Repo:** https://github.com/j0rdiun/cosmic-ext-app-switcher
- **Latest release:** v0.1.3
- **Install:** `curl -fsSL https://raw.githubusercontent.com/j0rdiun/cosmic-ext-app-switcher/main/install.sh | bash`