### PR TITLE
chore: use animated GIF for cosmic-ext-app-switcher preview

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -179,7 +179,7 @@ Applets(
       name: "cosmic-ext-app-switcher",
       description: "macOS-style Super+Tab app switcher for COSMIC — horizontal icon strip overlay with Dark, Light, Frosted, and Midnight themes",
       repo: "https://github.com/j0rdiun/cosmic-ext-app-switcher",
-      image: "https://raw.githubusercontent.com/j0rdiun/cosmic-ext-app-switcher/main/docs/screenshot-applet.png"
+      image: "https://raw.githubusercontent.com/j0rdiun/cosmic-ext-app-switcher/main/docs/app-switcher.gif"
     )
   ]
 )


### PR DESCRIPTION
Swaps the static applet screenshot for an animated GIF that shows the Super+Tab overlay switcher in action — gives a much better sense of what the applet actually does.