### PR TITLE
Add cosmic-connect applet

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -225,6 +225,12 @@ Applets(
       image: "https://github.com/skylord123/cosmic-cpufreq/raw/master/img.png"
     ),
     (
+      name: "cosmic-connect",
+      description: "KDE Connect panel applet for COSMIC™ — manage paired devices, send ping/ring, sync clipboard, share files/URLs/text, browse SFTP, SMS conversations, notification mirroring, media playback control, and file transfer progress",
+      repo: "https://github.com/AceMythos/cosmic-connect",
+      image: "https://raw.githubusercontent.com/AceMythos/cosmic-connect/main/screenshots/popup.jpeg"
+    ),
+    (
       name: "cosmic-applet-claude-usage",
       description: "Minimal panel applet showing Claude Code usage as a quiet, color-coded indicator",
       repo: "https://github.com/osterbergsimon/cosmic-applet-claude-usage",


### PR DESCRIPTION
Adds [cosmic-connect](https://github.com/AceMythos/cosmic-connect) — a KDE Connect panel applet for the COSMIC desktop.

Features: paired device management, ping/ring, clipboard sync, file/URL/text sharing, SFTP browsing, SMS conversations, notification mirroring, media playback control, pairing management, and real-time file transfer progress via a patched KDE Connect fork.