### PR TITLE
Update cosmic-power-monitor screenshot and description

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -190,9 +190,9 @@ Applets(
     ),
     (
       name: "cosmic-power-monitor",
-      description: "Battery power monitor applet for the COSMIC™ desktop",
+      description: "Battery power monitor applet for the COSMIC™ desktop with smooth animated power display and battery bar popup",
       repo: "https://github.com/AceMythos/cosmic-power-monitor",
-      image: "https://raw.githubusercontent.com/AceMythos/cosmic-power-monitor/main/screenshots/popup.png"
+      image: "https://raw.githubusercontent.com/AceMythos/cosmic-power-monitor/main/screenshots/charge.png"
     ),
     (
       name: "cosmic-ext-applet-now-playing",

--- a/applets.ron
+++ b/applets.ron
@@ -192,7 +192,7 @@ Applets(
       name: "cosmic-power-monitor",
       description: "Battery power monitor applet for the COSMIC™ desktop with smooth animated power display and battery bar popup",
       repo: "https://github.com/AceMythos/cosmic-power-monitor",
-      image: "https://raw.githubusercontent.com/AceMythos/cosmic-power-monitor/main/screenshots/charge.png"
+      image: "https://raw.githubusercontent.com/AceMythos/cosmic-power-monitor/main/screenshots/discharge.png"
     ),
     (
       name: "cosmic-ext-applet-now-playing",


### PR DESCRIPTION
Updates the screenshot URL from popup.png to discharge.png and the description to reflect new features (smooth animated power display, battery bar popup).