### PR TITLE
Fix RON syntax in applications list

### DIFF
--- a/applications.ron
+++ b/applications.ron
@@ -181,10 +181,10 @@ Applications(
       description: "Super STT enables effortless voice-to-text in any application, using the most advanced speech models that run 100% locally.",
       repo: "https://github.com/jorge-menjivar/super-stt",
       image: "https://raw.githubusercontent.com/jorge-menjivar/super-stt/refs/heads/main/.github/assets/demo-smaller.gif"
-    )
+    ),
     (
       name: "cosmic-tiling-manager",
-      description: "A GUI utility to manage window auto-tiling exceptions on the COSMIC Desktop Environment."
+      description: "A GUI utility to manage window auto-tiling exceptions on the COSMIC Desktop Environment.",
       repo: "https://github.com/maugustolo/cosmic-tiling-manager",
       image: "https://raw.githubusercontent.com/maugustolo/cosmic-tiling-manager/main/assets/screenshot.png"
     ),


### PR DESCRIPTION
The cosmic-tiling-manager entry is missing a comma after the preceding element and after its own description, so ron::from_str fails with ExpectedComma and the README/site generator panics before writing anything. Confirmed cargo run succeeds with this applied.