### PR TITLE
Add cosmictify — Spotify panel applet for COSMIC Desktop

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -308,5 +308,11 @@ Applets(
       repo: "https://github.com/raph-ael/cosmic-keepass",
       image: None,
     ),
+    (
+      name: "cosmictify",
+      description: "Spotify panel applet for COSMIC Desktop — now playing, animated marquee, progress bar, and MPRIS media controls. Spotify-only MPRIS (won't hijack YouTube/browser players).",
+      repo: "https://github.com/brunocasarotti/cosmictify",
+      image: None,
+    ),
   ]
 )


### PR DESCRIPTION
Adds [Cosmictify](https://github.com/brunocasarotti/cosmictify) to the applets collection.

**Cosmictify** is a Spotify panel applet for COSMIC Desktop / Pop!_OS: album cover, animated marquee (Title — Artist), progress bar, and MPRIS media controls. Spotify-only MPRIS — won't hijack YouTube/browser players. Built with Rust + libcosmic.

- **App ID:** `com.brunocasarotti.Cosmictify`
- **License:** MIT
- **Install:** `curl -fsSL https://raw.githubusercontent.com/brunocasarotti/cosmictify/main/install.sh | bash`