### PR TITLE
Add cosmic-ext-applet-cheatsheet to the applets list

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -326,5 +326,11 @@ Applets(
       repo: "https://github.com/stldave314/cosmic-media-now-playing-applet",
       image: "https://github.com/stldave314/cosmic-media-now-playing-applet/raw/main/resources/screenshot-popup.png",
     ),
+    (
+      name: "cosmic-ext-applet-cheatsheet",
+      description: "Searchable cheat sheet of your real keyboard shortcuts, read from your own COSMIC config including custom bindings. Opens as a panel applet or a Super+C overlay, with a learning mode to hide the ones you already know.",
+      repo: "https://github.com/tomashaa/cosmic-ext-applet-cheatsheet",
+      image: "https://raw.githubusercontent.com/tomashaa/cosmic-ext-applet-cheatsheet/main/assets/screenshot.jpg",
+    ),
   ]
 )


### PR DESCRIPTION
Adds [cosmic-ext-applet-cheatsheet](https://github.com/tomashaa/cosmic-ext-applet-cheatsheet) to `applets.ron`.

A searchable cheat sheet for COSMIC keyboard shortcuts. Rather than shipping a hardcoded list, it reads the user's actual shortcut config — the COSMIC defaults plus any custom bindings — so what it shows is what is really bound on that machine. It opens either as a panel applet or as a Super+C overlay, and has a learning mode that hides shortcuts you have marked as known.

Built with libcosmic, GPL-3.0, i18n via Fluent (9 languages).

Only `applets.ron` is modified — `README.md` and `docs/index.html` are generated, and I verified the entry parses and renders by running the generator locally.

![screenshot](https://raw.githubusercontent.com/tomashaa/cosmic-ext-applet-cheatsheet/main/assets/screenshot.jpg)